### PR TITLE
Fix error with Go Modules

### DIFF
--- a/logflag.go
+++ b/logflag.go
@@ -27,7 +27,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // stringslice stores multi-value command line arguments.


### PR DESCRIPTION
This fixes this error with Go Modules:
```
go: <module-path> imports
	github.com/reenjii/logflag imports
	github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.8.1: parsing go.mod:
	module declares its path as: github.com/sirupsen/logrus
	        but was required as: github.com/Sirupsen/logrus
```